### PR TITLE
feat: replace command with MicroBatchFramework

### DIFF
--- a/src/Base64UrlCore.sln
+++ b/src/Base64UrlCore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.168
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28621.142
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Base64UrlCore", "Base64UrlCore\Base64UrlCore.csproj", "{A358D2B0-3510-434B-A228-F8D07877DE29}"
 EndProject
@@ -9,7 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Base64UrlCore.Tests", "Base
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dotnettool", "dotnettool", "{BB8077BE-5606-4333-9CF8-BE3D8A7DFAD8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "base64urls", "base64urls\base64urls.csproj", "{C0EF60D7-3B0F-4AA2-A66B-C3C20911E224}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "base64urls", "base64urls\base64urls.csproj", "{C0EF60D7-3B0F-4AA2-A66B-C3C20911E224}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "base64urls.batch", "base64urls.batch\base64urls.batch.csproj", "{5288FB44-649B-454D-9118-3313605F1B43}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,12 +31,17 @@ Global
 		{C0EF60D7-3B0F-4AA2-A66B-C3C20911E224}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C0EF60D7-3B0F-4AA2-A66B-C3C20911E224}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C0EF60D7-3B0F-4AA2-A66B-C3C20911E224}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5288FB44-649B-454D-9118-3313605F1B43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5288FB44-649B-454D-9118-3313605F1B43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5288FB44-649B-454D-9118-3313605F1B43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5288FB44-649B-454D-9118-3313605F1B43}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{C0EF60D7-3B0F-4AA2-A66B-C3C20911E224} = {BB8077BE-5606-4333-9CF8-BE3D8A7DFAD8}
+		{5288FB44-649B-454D-9118-3313605F1B43} = {BB8077BE-5606-4333-9CF8-BE3D8A7DFAD8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AB5DCAD9-B85C-4D03-B6DB-1AEAB3F4E51B}

--- a/src/base64urls.batch/Program.cs
+++ b/src/base64urls.batch/Program.cs
@@ -1,6 +1,8 @@
 ﻿using MicroBatchFramework;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -10,45 +12,60 @@ namespace Base64UrlCore.Tool
     {
         static async Task Main(string[] args)
         {
-            // TODO: override default error
-            // TODO: override default help message
-            // TODO: Is any simple way to provide unix style help: -version --version -v / -help --help -h
-            await new HostBuilder().RunBatchEngineAsync<Base64Batch>(args);
+            await new HostBuilder().RunBatchEngineAsync<Base64Batch>(ArgsInterceptor(args));
+        }
+
+        /// <summary>
+        /// if args if empty, return 
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        static string[] ArgsInterceptor(string[] args)
+        {
+            return !args.Any()
+                // MEMO: override default error
+                ? new[] { "-help" }
+                : args
+                    // MEMO: override default help message
+                    .Select(x => string.Equals("help", x, StringComparison.OrdinalIgnoreCase) ? "-help" : x)
+                    // MEMO: override default list message
+                    .Select(x => string.Equals("list", x, StringComparison.OrdinalIgnoreCase) ? "-help" : x)
+                    .ToArray();
         }
     }
 
     public class Base64Batch : BatchBase
-    {
-        [Command("encode")]
+    { 
+        [Command("encode", "encode input string to base64url")]
         public void Encode([Option(0)]string input) => Console.WriteLine(Base64Url.Encode(input));
 
-        [Command("decode")]
+        [Command("decode", "decode input base64url to string")]
         public void Decode([Option(0)]string input) => Console.WriteLine(Base64Url.Decode(input));
 
-        [Command("escape")]
+        [Command("escape", "escape base64 to base64url")]
         public void Escape([Option(0)]string input) => Console.WriteLine(Base64Url.Escape(input));
 
-        [Command("unescape")]
+        [Command("unescape", "unescape base64url to base64")]
         public void Unescape([Option(0)]string input) => Console.WriteLine(Base64Url.Unescape(input));
 
         /// <summary>
-        /// -v -version --version
+        /// Provide unix style command argument: -version --version -v
         /// </summary>
-        [Command("-v")]
+        [Command("-v", "show version")]
         public void Version1() => ShowVersion();
-        [Command("-version")]
+        [Command("-version", "show version")]
         public void Version2() => ShowVersion();
-        [Command("--version")]
+        [Command("--version", "show version")]
         public void Version3() => ShowVersion();
 
         /// <summary>
-        /// -h -help --help
+        /// Provide unix style command argument: -help --help -h
         /// </summary>
-        [Command("-h")]
+        [Command("-h", "show help")]
         public void Help1() => ShowHelp();
-        [Command("-help")]
+        [Command("-help", "show help")]
         public void Help2() => ShowHelp();
-        [Command("--help")]
+        [Command("--help", "show help")]
         public void Help3() => ShowHelp();
 
         private void ShowVersion()
@@ -62,7 +79,7 @@ namespace Base64UrlCore.Tool
 
         private void ShowHelp()
         {
-            Console.WriteLine("Usage: dotnet base64urls [-version] [-help] [decode|encode|escape|unescape] [args]");
+            Console.WriteLine("Usage: base64urls [-version] [-help] [decode|encode|escape|unescape] [args]");
             Console.WriteLine("E.g., run this: base64urls decode QyMgaXMgYXdlc29tZQ==");
             Console.WriteLine("E.g., run this: base64urls encode \"C# is awesome.\"");
             Console.WriteLine("E.g., run this: base64urls escape \"This+is/goingto+escape==\"");

--- a/src/base64urls.batch/Program.cs
+++ b/src/base64urls.batch/Program.cs
@@ -1,0 +1,72 @@
+﻿using MicroBatchFramework;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Base64UrlCore.Tool
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            // TODO: override default error
+            // TODO: override default help message
+            // TODO: Is any simple way to provide unix style help: -version --version -v / -help --help -h
+            await new HostBuilder().RunBatchEngineAsync<Base64Batch>(args);
+        }
+    }
+
+    public class Base64Batch : BatchBase
+    {
+        [Command("encode")]
+        public void Encode([Option(0)]string input) => Console.WriteLine(Base64Url.Encode(input));
+
+        [Command("decode")]
+        public void Decode([Option(0)]string input) => Console.WriteLine(Base64Url.Decode(input));
+
+        [Command("escape")]
+        public void Escape([Option(0)]string input) => Console.WriteLine(Base64Url.Escape(input));
+
+        [Command("unescape")]
+        public void Unescape([Option(0)]string input) => Console.WriteLine(Base64Url.Unescape(input));
+
+        /// <summary>
+        /// -v -version --version
+        /// </summary>
+        [Command("-v")]
+        public void Version1() => ShowVersion();
+        [Command("-version")]
+        public void Version2() => ShowVersion();
+        [Command("--version")]
+        public void Version3() => ShowVersion();
+
+        /// <summary>
+        /// -h -help --help
+        /// </summary>
+        [Command("-h")]
+        public void Help1() => ShowHelp();
+        [Command("-help")]
+        public void Help2() => ShowHelp();
+        [Command("--help")]
+        public void Help3() => ShowHelp();
+
+        private void ShowVersion()
+        {
+            var version = Assembly.GetEntryAssembly()
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                .InformationalVersion
+                .ToString();
+            Console.WriteLine($"base64urls v{version}");
+        }
+
+        private void ShowHelp()
+        {
+            Console.WriteLine("Usage: dotnet base64urls [-version] [-help] [decode|encode|escape|unescape] [args]");
+            Console.WriteLine("E.g., run this: base64urls decode QyMgaXMgYXdlc29tZQ==");
+            Console.WriteLine("E.g., run this: base64urls encode \"C# is awesome.\"");
+            Console.WriteLine("E.g., run this: base64urls escape \"This+is/goingto+escape==\"");
+            Console.WriteLine("E.g., run this: base64urls unescape \"This-is_goingto-escape\"");
+        }
+    }
+}

--- a/src/base64urls.batch/Program.cs
+++ b/src/base64urls.batch/Program.cs
@@ -9,7 +9,21 @@ namespace Base64UrlCore.Tool
 {
     class Program
     {
-        private static readonly string[] validCommand = new[]
+        static async Task Main(string[] args)
+        {
+            if (args.Any() && !IsValidCommand(args[0]))
+            {
+                args = new[] { "help" }.ToArray();
+            }
+            await new HostBuilder().RunBatchEngineAsync<Base64Batch>(args);
+        }
+
+        /// <summary>
+        /// Ready for fallback to help when f none of arg is match to valid command. E.G., `base64urls unexceptected` should not acceptable.
+        /// </summary>
+        /// <param name="command"></param>
+        /// <returns></returns>
+        private static bool IsValidCommand(string command) => new[]
         {
             "help", "list", "-h", "-help", "--help",
             "version", "-v", "-version", "--version",
@@ -17,16 +31,7 @@ namespace Base64UrlCore.Tool
             "decode",
             "escape",
             "unescape",
-        };
-        static async Task Main(string[] args)
-        {
-            if (args == null || !args.Any() || !validCommand.Contains(args[0]))
-            {
-                args = new[] { "help" }.ToArray();
-            }
-            // TODO: How to fallback if none of arg is match to command. E.G., `base64urls version`
-            await new HostBuilder().RunBatchEngineAsync<Base64Batch>(args);
-        }
+        }.Contains(command);
     }
 
     public class Base64Batch : BatchBase
@@ -47,7 +52,7 @@ namespace Base64UrlCore.Tool
         /// Provide unix style command argument: -version --version -v + version command
         /// </summary>
         [Command(new[] { "version", "-v", "-version", "--version" }, "show version")]
-        public void ShowVersion()
+        public void Version()
         {
             var version = Assembly.GetEntryAssembly()
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
@@ -59,8 +64,11 @@ namespace Base64UrlCore.Tool
         /// <summary>
         /// Provide unix style command argument: -help --help -h + override default help / list
         /// </summary>
+        /// <remarks>
+        /// Also override default help. no arguments execution will fallback to here.
+        /// </remarks>
         [Command(new[] { "help", "list", "-h", "-help", "--help" }, "show help")]
-        public void ShowHelp()
+        public void Help()
         {
             Console.WriteLine("Usage: base64urls [-version] [-help] [decode|encode|escape|unescape] [args]");
             Console.WriteLine("E.g., run this: base64urls decode QyMgaXMgYXdlc29tZQ==");

--- a/src/base64urls.batch/Program.cs
+++ b/src/base64urls.batch/Program.cs
@@ -11,26 +11,12 @@ namespace Base64UrlCore.Tool
     {
         static async Task Main(string[] args)
         {
+            if (args == null || !args.Any())
+            {
+                args = new[] { "help" }.ToArray();
+            }
             // TODO: How to fallback if none of arg is match to command. E.G., `base64urls version`
-            await new HostBuilder().RunBatchEngineAsync<Base64Batch>(ArgsInterceptor(args));
-        }
-
-        /// <summary>
-        /// override MicroBatchFramework's default command.
-        /// </summary>
-        /// <param name="args"></param>
-        /// <returns></returns>
-        static string[] ArgsInterceptor(string[] args)
-        {
-            return !args.Any()
-                // MEMO: override default error
-                ? new[] { "-help" }
-                : args
-                    // MEMO: override default help message
-                    .Select(x => string.Equals("help", x, StringComparison.OrdinalIgnoreCase) ? "-help" : x)
-                    // MEMO: override default list message
-                    .Select(x => string.Equals("list", x, StringComparison.OrdinalIgnoreCase) ? "-help" : x)
-                    .ToArray();
+            await new HostBuilder().RunBatchEngineAsync<Base64Batch>(args);
         }
     }
 
@@ -49,26 +35,10 @@ namespace Base64UrlCore.Tool
         public void Unescape([Option(0)]string input) => Console.WriteLine(Base64Url.Unescape(input));
 
         /// <summary>
-        /// Provide unix style command argument: -version --version -v
+        /// Provide unix style command argument: -version --version -v + version command
         /// </summary>
-        [Command("-v", "show version")]
-        public void Version1() => ShowVersion();
-        [Command("-version", "show version")]
-        public void Version2() => ShowVersion();
-        [Command("--version", "show version")]
-        public void Version3() => ShowVersion();
-
-        /// <summary>
-        /// Provide unix style command argument: -help --help -h
-        /// </summary>
-        [Command("-h", "show help")]
-        public void Help1() => ShowHelp();
-        [Command("-help", "show help")]
-        public void Help2() => ShowHelp();
-        [Command("--help", "show help")]
-        public void Help3() => ShowHelp();
-
-        private void ShowVersion()
+        [Command(new[] { "version", "-v", "-version", "--version" }, "show version")]
+        public void ShowVersion()
         {
             var version = Assembly.GetEntryAssembly()
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
@@ -77,7 +47,11 @@ namespace Base64UrlCore.Tool
             Console.WriteLine($"base64urls v{version}");
         }
 
-        private void ShowHelp()
+        /// <summary>
+        /// Provide unix style command argument: -help --help -h + override default help / list
+        /// </summary>
+        [Command(new[] { "help", "list", "-h", "-help", "--help" }, "show help")]
+        public void ShowHelp()
         {
             Console.WriteLine("Usage: base64urls [-version] [-help] [decode|encode|escape|unescape] [args]");
             Console.WriteLine("E.g., run this: base64urls decode QyMgaXMgYXdlc29tZQ==");

--- a/src/base64urls.batch/Program.cs
+++ b/src/base64urls.batch/Program.cs
@@ -9,9 +9,18 @@ namespace Base64UrlCore.Tool
 {
     class Program
     {
+        private static readonly string[] validCommand = new[]
+        {
+            "help", "list", "-h", "-help", "--help",
+            "version", "-v", "-version", "--version",
+            "encode",
+            "decode",
+            "escape",
+            "unescape",
+        };
         static async Task Main(string[] args)
         {
-            if (args == null || !args.Any())
+            if (args == null || !args.Any() || !validCommand.Contains(args[0]))
             {
                 args = new[] { "help" }.ToArray();
             }

--- a/src/base64urls.batch/Program.cs
+++ b/src/base64urls.batch/Program.cs
@@ -11,6 +11,7 @@ namespace Base64UrlCore.Tool
     {
         static async Task Main(string[] args)
         {
+            // TODO: How to fallback if none of arg is match to command. E.G., `base64urls version`
             await new HostBuilder().RunBatchEngineAsync<Base64Batch>(ArgsInterceptor(args));
         }
 

--- a/src/base64urls.batch/Program.cs
+++ b/src/base64urls.batch/Program.cs
@@ -1,6 +1,5 @@
 ﻿using MicroBatchFramework;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Reflection;
@@ -16,7 +15,7 @@ namespace Base64UrlCore.Tool
         }
 
         /// <summary>
-        /// if args if empty, return 
+        /// override MicroBatchFramework's default command.
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>

--- a/src/base64urls.batch/Properties/launchSettings.json
+++ b/src/base64urls.batch/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "base64urls.batch": {
       "commandName": "Project",
-      "commandLineArgs": "encode \"C# is awesome.\""
+      "commandLineArgs": "version"
     }
   }
 }

--- a/src/base64urls.batch/Properties/launchSettings.json
+++ b/src/base64urls.batch/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "base64urls.batch": {
       "commandName": "Project",
-      "commandLineArgs": "invalid"
+      "commandLineArgs": "unexpected"
     }
   }
 }

--- a/src/base64urls.batch/Properties/launchSettings.json
+++ b/src/base64urls.batch/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "base64urls.batch": {
+      "commandName": "Project",
+      "commandLineArgs": "encode \"C# is awesome.\""
+    }
+  }
+}

--- a/src/base64urls.batch/Properties/launchSettings.json
+++ b/src/base64urls.batch/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "base64urls.batch": {
       "commandName": "Project",
-      "commandLineArgs": "version"
+      "commandLineArgs": "invalid"
     }
   }
 }

--- a/src/base64urls.batch/base64urls.batch.csproj
+++ b/src/base64urls.batch/base64urls.batch.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MicroBatchFramework" Version="0.4.1-beta5" />
+    <PackageReference Include="MicroBatchFramework" Version="0.4.5-beta9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/base64urls.batch/base64urls.batch.csproj
+++ b/src/base64urls.batch/base64urls.batch.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MicroBatchFramework" Version="0.4.1-beta5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Base64UrlCore\Base64UrlCore.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## TL;DR;

Try replace own command parser to [MicroBatchFramework](https://github.com/Cysharp/MicroBatchFramework).
Aim to establish simple command handling without thinking about args.

## Summary

Left : MicroBatchFramework / Right : Self command parser

![image](https://user-images.githubusercontent.com/3856350/53905203-43954a80-408b-11e9-8a93-f05370136162.png)


## TODO

- [x] override default error
  - interceptor?
- [x] override default help message
  - seems like not the usecase, though? https://github.com/Cysharp/MicroBatchFramework/blob/master/src/MicroBatchFramework/CommandAttribute.cs#L15
- [x] Is any simple way to provide unix style help: -version --version -v / -help --help -h
  - should be require new Command Constructor.
- [x] Handle how to fallback to help when none of command match to args.
